### PR TITLE
fix: add missing YAML frontmatter to skill-creator agent files

### DIFF
--- a/skills/skill-creator/agents/analyzer.md
+++ b/skills/skill-creator/agents/analyzer.md
@@ -1,3 +1,8 @@
+---
+name: skill-creator-analyzer
+description: Analyzes blind comparison results to identify why the winning skill outperformed the loser and generate actionable improvement suggestions. Read and follow when post-hoc analysis of eval results is needed.
+---
+
 # Post-hoc Analyzer Agent
 
 Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.

--- a/skills/skill-creator/agents/comparator.md
+++ b/skills/skill-creator/agents/comparator.md
@@ -1,3 +1,8 @@
+---
+name: skill-creator-comparator
+description: Blind comparison agent that judges which of two outputs better completes a task without knowing which skill produced them. Read and follow to run unbiased A/B output comparisons.
+---
+
 # Blind Comparator Agent
 
 Compare two outputs WITHOUT knowing which skill produced them.

--- a/skills/skill-creator/agents/grader.md
+++ b/skills/skill-creator/agents/grader.md
@@ -1,3 +1,8 @@
+---
+name: skill-creator-grader
+description: Grades assertion results against execution transcripts and output files. Read and follow to evaluate whether each expectation passes or fails with supporting evidence.
+---
+
 # Grader Agent
 
 Evaluate expectations against an execution transcript and outputs.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The three agent files in `skills/skill-creator/agents/` — `analyzer.md`, `grader.md`, and `comparator.md` — are missing their YAML frontmatter blocks entirely. Without a `---`-delimited frontmatter section containing at least `name:` and `description:`, the Claude Code runtime cannot register these files as named agents.

**Impact:** `skills/skill-creator/SKILL.md` references all three agents by path and instructs the runtime to "read" and "spawn" them. Because they have no frontmatter, the runtime treats them as plain markdown rather than registered agents, so the skill-creator evaluation loop (grader → comparator → analyzer) silently fails.

## Fix

Added a minimal YAML frontmatter block to the top of each file, matching the pattern used by `template/SKILL.md` and `skills/skill-creator/SKILL.md`:

```yaml
---
name: skill-creator-grader
description: Grades assertion results against execution transcripts and output files. ...
---
```

No other content was changed. The body of each agent file is valid and well-structured.

## Files Changed

| File | Fix |
|------|-----|
| `skills/skill-creator/agents/analyzer.md` | Added `name: skill-creator-analyzer` + description |
| `skills/skill-creator/agents/grader.md` | Added `name: skill-creator-grader` + description |
| `skills/skill-creator/agents/comparator.md` | Added `name: skill-creator-comparator` + description |