### PR TITLE
docs: fix stale project references in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Please use the [GitHub Issues](https://github.com/guanyang/open-agent-hub/issues
 
 1.  **Clone your fork**:
     ```bash
-    git clone https://github.com/YOUR_USERNAME/antigravity-skills.git
+    git clone https://github.com/YOUR_USERNAME/open-agent-hub.git
     ```
 2.  **Create a feature branch**:
     ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Antigravity Skills
+# Contributing to open-agent-hub
 
-Thank you for your interest in contributing to Antigravity Skills! We welcome contributions from the community to help make agents more capable and professional.
+Thank you for your interest in contributing to open-agent-hub! We welcome contributions from the community to help make agents more capable and professional.
 
 ## 🚀 How to Contribute
 
@@ -19,7 +19,7 @@ We value clear documentation. You can improve existing manuals, README files, or
 - We maintain bilingual support (English/Chinese) for major documentation.
 
 ### 3. Reporting Bugs
-Please use the [GitHub Issues](https://github.com/guanyang/antigravity-skills/issues) to report bugs or technical failures. Provide as much context as possible, including:
+Please use the [GitHub Issues](https://github.com/guanyang/open-agent-hub/issues) to report bugs or technical failures. Provide as much context as possible, including:
 - The skill being used.
 - The AI tool/Agent being used.
 - Steps to reproduce the issue.


### PR DESCRIPTION
## 📝 Description

  Updates `CONTRIBUTING.md` to replace stale `Antigravity Skills`
  references with `open-agent-hub`.

  This also points bug reports and fork clone instructions to the current
  repository, preventing new contributors from being directed to the wrong
  issue tracker or clone URL.

  No linked issue; this is a small documentation-only fix.

  ## 🚀 Type of Change

  - [ ] 🐛 **Bug fix** (non-breaking change which fixes an issue)
  - [ ] ✨ **New feature** (non-breaking change which adds functionality)
  - [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to not work as
  expected)
  - [x] 🧾 **Documentation** (update or new documentation)
  - [ ] 🎨 **Style/Refactoring** (formatting, renaming, cleanup; no functional changes)
  - [ ] 🤖 **AI/Prompt Engineering** (changes related to prompts, agent skills, or model configs)

  ## ✅ Validation

  - `git diff --check`
  - `npm test` (the repository's placeholder test script exits successfully)

  ## ✅ Checklist

  - [x] My changes follow the existing documentation style.
  - [x] I have performed a self-review of the changes.
  - [x] No code comments are needed because this is documentation-only.
  - [x] I have made the corresponding documentation changes.
  - [x] No new tests are needed for this documentation-only change.
  - [x] I verified the changes in a sandboxed environment.

  ## 📸 Screenshots

  Not applicable — this change only updates documentation text and links.